### PR TITLE
Remove replacement rule for participle in go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All values are immutable. However to improve ergonomics any mutating operations 
 automatically perform a copy. In reality the implementation should avoid copies 
 wherever possible while maintaining the semantics of immutability.
 
-Each parameter has two potential tains:
+Each parameter has two potential taints:
 
 1. A mutation taint that states whether the function mutates the 
    parameter value.

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,3 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 )
-
-replace github.com/alecthomas/participle => /Users/aat/Projects/participle


### PR DESCRIPTION
Also, fix a tiny typo in the README.